### PR TITLE
chore: add new annotation fields: release-id and release-name

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -74,15 +74,23 @@ Except for explictly stated, the required annotations SHOULD be provided by the 
 
 - **`vnd.tier4.web-auto.env`** *string*
 
-  OPTIONAL. The web-auto environment name, like `dev`, `stg`, `prd`.
+  OPTIONAL, recommended. The web-auto environment name, like `dev`, `stg`, `prd`.
+
+- **`vnd.tier4.web-auto.cicd.release-id`** *string*
+
+  OPTIONAL, recommended. The release ID for this build on the evaluator firmware release.
+
+- **`vnd.tier4.web-auto.cicd.release-name`** *string*
+
+  OPTIONAL, recommended. The release display name for this build on the evaluator firmware release.
 
 - **`vnd.tier4.pilot-auto.platform.ecu.hardware-model`** *string*
 
-  OPTIONAL. The hardware model of the ECU.
+  OPTIONAL, recommended. The hardware model of the ECU. This information should be provided by the user.
 
 - **`vnd.tier4.pilot-auto.platform.ecu.hardware-series`** *string*
 
-  OPTIONAL. The hardware series of the ECU.
+  OPTIONAL, recommended. The hardware series of the ECU. This information should be provided by the user.
 
 - **`vnd.tier4.image.os`** *string*
   OPTIONAL, recommended. The operating system of the original system rootfs image, like `Ubuntu`, `Debian`, etc.

--- a/src/ota_image_libs/v1/annotation_keys.py
+++ b/src/ota_image_libs/v1/annotation_keys.py
@@ -34,6 +34,8 @@ WEB_AUTO_PROJECT = "vnd.tier4.web-auto.project"
 WEB_AUTO_PROJECT_ID = "vnd.tier4.web-auto.project-id"
 WEB_AUTO_CATALOG = "vnd.tier4.web-auto.catalog"
 WEB_AUTO_CATALOG_ID = "vnd.tier4.web-auto.catalog-id"
+WEB_AUTO_CICD_RELEASE_ID = "vnd.tier4.web-auto.cicd.release-id"
+WEB_AUTO_CICD_RELEASE_NAME = "vnd.tier4.web-auto.cicd.release-name"
 
 #
 # ------ OTA related ------ #

--- a/src/ota_image_libs/v1/image_index/schema.py
+++ b/src/ota_image_libs/v1/image_index/schema.py
@@ -39,6 +39,8 @@ from ota_image_libs.v1.annotation_keys import (
     PILOT_AUTO_PROJECT_VERSION,
     WEB_AUTO_CATALOG,
     WEB_AUTO_CATALOG_ID,
+    WEB_AUTO_CICD_RELEASE_ID,
+    WEB_AUTO_CICD_RELEASE_NAME,
     WEB_AUTO_ENV,
     WEB_AUTO_PROJECT,
     WEB_AUTO_PROJECT_ID,
@@ -78,6 +80,8 @@ class ImageIndex(MetaFileBase):
         web_auto_catalog: Union[str, None] = Field(alias=WEB_AUTO_CATALOG, default=None)
         web_auto_catalog_id: Union[str, None] = Field(alias=WEB_AUTO_CATALOG_ID, default=None)
         web_auto_env: Union[str, None] = Field(alias=WEB_AUTO_ENV, default=None)
+        web_auto_cicd_release_id: Union[str, None] = Field(alias=WEB_AUTO_CICD_RELEASE_ID, default=None)
+        web_auto_cicd_release_name: Union[str, None] = Field(alias=WEB_AUTO_CICD_RELEASE_NAME, default=None)
         # fmt: on
 
     SchemaVersion = SchemaVersion[2]


### PR DESCRIPTION
## Introduction

This PR adds two new fields to the annotations, `vnd.tier4.web-auto.cicd.release-id` and `vnd.tier4.web-auto.cicd.release-name`, corresponding to the `release-id` and `release-name` shown on the firmware release.