### PR TITLE
chore(ota-image-tools): fix metafiles print not preserving the correct annotation keys

### DIFF
--- a/src/ota_image_tools/_utils.py
+++ b/src/ota_image_tools/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import sys
 import threading
@@ -55,3 +56,7 @@ def measure_timecost(_func: Callable[P, RT]) -> Callable[P, RT]:
         return _res
 
     return _wrapped
+
+
+def ppformat_json_string(_in: str) -> str:
+    return json.dumps(json.loads(_in), indent=2)

--- a/src/ota_image_tools/cmds/deploy_image.py
+++ b/src/ota_image_tools/cmds/deploy_image.py
@@ -18,12 +18,15 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from pprint import pformat
 from typing import TYPE_CHECKING
 
 from ota_image_libs.v1.artifact.reader import OTAImageArtifactReader
 from ota_image_libs.v1.image_manifest.schema import ImageIdentifier
-from ota_image_tools._utils import exit_with_err_msg, measure_timecost
+from ota_image_tools._utils import (
+    exit_with_err_msg,
+    measure_timecost,
+    ppformat_json_string,
+)
 from ota_image_tools.libs.deploy_image import (
     CONCURRENT_JOBS,
     READ_SIZE,
@@ -151,21 +154,22 @@ def deploy_image_cmd(args: Namespace) -> None:  # pragma: no cover
         logger.info(f"will use system image payload with {image_id=}.")
         workdir_setup = OTAImageDeployerSetup(image_id, artifact=image, workdir=workdir)
 
+        _image_index = workdir_setup.image_index
         logger.info(
-            "OTA image index labels: \n"
-            f"{pformat(workdir_setup.image_index.annotations.model_dump(exclude_none=True))}"
+            f"OTA image index: {ppformat_json_string(_image_index.export_metafile())}"
         )
 
-        assert workdir_setup.image_manifest
+        _image_manifest = workdir_setup.image_manifest
+        assert _image_manifest
         logger.info(
             f"OTA image manifest annotations for {image_id=}: \n"
-            f"{pformat(workdir_setup.image_manifest.annotations.model_dump(exclude_none=True))}"
+            f"{ppformat_json_string(_image_manifest.export_metafile())}"
         )
 
         image_config = workdir_setup.image_config
         logger.info(
             "system image statistics: \n"
-            f"{pformat(image_config.labels.model_dump(exclude_none=True))}"
+            f"{ppformat_json_string(image_config.export_metafile())}"
         )
 
         logger.info("deploy resources for later setting rootfs ...")

--- a/src/ota_image_tools/cmds/inspect_index.py
+++ b/src/ota_image_tools/cmds/inspect_index.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from ota_image_libs.v1.artifact.reader import OTAImageArtifactReader
 from ota_image_libs.v1.consts import IMAGE_INDEX_FNAME
 from ota_image_libs.v1.utils import check_if_valid_ota_image
-from ota_image_tools._utils import exit_with_err_msg
+from ota_image_tools._utils import exit_with_err_msg, ppformat_json_string
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
@@ -61,10 +61,6 @@ def inspect_index_cmd(args: Namespace) -> None:
 
     if image_root.is_file():
         with OTAImageArtifactReader(image_root) as artifact_reader:
-            return print(
-                artifact_reader.parse_index().model_dump_json(
-                    indent=2, exclude_none=True
-                )
-            )
-
+            _image_index = artifact_reader.parse_index()
+            return print(ppformat_json_string(_image_index.export_metafile()))
     exit_with_err_msg(f"{image_root} is not a folder nor an OTA image artifact!")

--- a/src/ota_image_tools/cmds/lookup_image.py
+++ b/src/ota_image_tools/cmds/lookup_image.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from ota_image_libs.v1.artifact.reader import OTAImageArtifactReader
 from ota_image_libs.v1.image_manifest.schema import ImageIdentifier, OTAReleaseKey
 from ota_image_libs.v1.utils import check_if_valid_ota_image
-from ota_image_tools._utils import exit_with_err_msg
+from ota_image_tools._utils import exit_with_err_msg, ppformat_json_string
 from ota_image_tools.libs.common import (
     resolve_image_from_artifact,
     resolve_image_from_folder,
@@ -103,10 +103,10 @@ def _lookup_image_from_artifact(
         if show_image_config:
             image_config, _ = artifact_reader.get_image_config(image_manifest)
             logger.info("image_config: ")
-            print(f"{image_config.model_dump_json(indent=2, exclude_none=True)}")
-
-        logger.info("image_manifest: ")
-        print(f"{image_manifest.model_dump_json(indent=2, exclude_none=True)}")
+            print(f"{ppformat_json_string(image_config.export_metafile())}")
+        else:
+            logger.info("image_manifest: ")
+            print(f"{ppformat_json_string(image_manifest.export_metafile())}")
 
 
 def lookup_image_cmd(args: Namespace) -> None:


### PR DESCRIPTION
## Introduction

Fix ota-image-tools commands that print metafiles without preserving the correct annotation keys. The `export_metafile` API should be used instead of directly dumping from pydantic `model_dump_json` API.