### PR TITLE
feat: add required libs for supporting OTA image signing with AWS KMS

### DIFF
--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Any
 
 import jwt
+from cryptography.hazmat.primitives.asymmetric import ec
 
 from .jwt_utils import (
     JWT_ALG_CURVE_MAPPING,
@@ -75,13 +76,11 @@ def compose_unsigned_jwt_for_aws_kms_sign(
     Raises:
         ValueError
     """
-    # drop the dummy signature, the leftover will become valid input
-    #   for actual JWT signing
     _aws_alg = get_aws_sign_alg(alg)
     _raw_payload = jwt.encode(
         payload=payload,
         headers=headers,
-        key="DUMMY_KEY",
+        key=ec.generate_private_key(JWT_ALG_CURVE_MAPPING[JWTAlgorithm(alg)]()),
         algorithm=alg,
     ).rsplit(".", 1)[0]
     return (_aws_alg, _raw_payload)

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -55,9 +55,7 @@ AWS_ALG_JWT_ALG_MAPPING = {v: k for k, v in JWT_ALG_AWS_ALG_MAPPING.items()}
 def get_aws_sign_alg(jwt_sign_alg: str) -> AWSKMSignAlgorithm:
     try:
         return JWT_ALG_AWS_ALG_MAPPING[JWTAlgorithm(jwt_sign_alg)]
-    except ValueError:
-        raise ValueError(f"unsupported or unknown {jwt_sign_alg=}") from None
-    except KeyError:
+    except (ValueError, KeyError):
         raise ValueError(f"unsupported or unknown {jwt_sign_alg=}") from None
 
 
@@ -111,13 +109,9 @@ def compose_jwt_from_aws_kms_sign_response(
     """
     try:
         _kms_sign_alg = AWSKMSignAlgorithm(kms_sign_algorithm)
-    except ValueError:
-        raise ValueError(f"unsupported or invalid {kms_sign_algorithm=}") from None
-
-    try:
         _curve = JWT_ALG_CURVE_MAPPING[AWS_ALG_JWT_ALG_MAPPING[_kms_sign_alg]]
-    except KeyError as e:
-        raise ValueError(f"unsupported or invalid algorithm: {e!r}") from None
+    except (ValueError, KeyError):
+        raise ValueError(f"unsupported or invalid {kms_sign_algorithm=}") from None
 
     _raw_sig = ec_sign_der_to_raw_signature(kms_sign_resp, _curve())
     return (_jwt_payload + b"." + base64url_encode(_raw_sig)).decode("ascii")

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -96,7 +96,7 @@ def compose_unsigned_jwt_for_aws_kms_sign(
 
 def compose_jwt_from_aws_kms_sign_response(
     _jwt_payload: bytes, *, kms_sign_resp: bytes, kms_sign_algorithm: str
-) -> bytes:
+) -> str:
     """Compose the complete JWT from JWT payload and AWS KMS signing resp.
 
     Caller needs to encode the payload and signature beforehand.
@@ -119,5 +119,5 @@ def compose_jwt_from_aws_kms_sign_response(
     except KeyError as e:
         raise ValueError(f"unsupported or invalid algorithm: {e!r}") from None
 
-    _raw_sig = ec_sign_der_to_raw_signature(kms_sign_resp, _curve)
-    return _jwt_payload + b"." + base64url_encode(_raw_sig)
+    _raw_sig = ec_sign_der_to_raw_signature(kms_sign_resp, _curve())
+    return (_jwt_payload + b"." + base64url_encode(_raw_sig)).decode("ascii")

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -94,12 +94,15 @@ def compose_unsigned_jwt_for_aws_kms_sign(
 
 
 def compose_jwt_from_aws_kms_sign_response(
-    _jwt_payload: bytes, *, kms_sign_resp: bytes, kms_sign_algorithm: str
+    _jwt_payload: str, *, kms_sign_resp: bytes, kms_sign_algorithm: str
 ) -> str:
     """Compose the complete signed JWT from the signing input and a KMS Sign response.
 
+    The caller should provide the exact same `_jwt_payload` previously retrieved from
+    `compose_unsigned_jwt_for_aws_kms_sign`.
+
     Args:
-        _jwt_payload: the JWT signing input (``header.payload``) as bytes.
+        _jwt_payload: the JWT signing input in base64_url encoded JWT format(``header.payload``).
         kms_sign_resp: the raw DER-encoded ECDSA signature taken from the KMS
             ``Sign`` response's ``Signature`` field.
         kms_sign_algorithm: the response's ``SigningAlgorithm`` (e.g. ``ECDSA_SHA_256``).
@@ -120,4 +123,6 @@ def compose_jwt_from_aws_kms_sign_response(
         raise ValueError(f"unsupported or invalid {kms_sign_algorithm=}") from None
 
     _raw_sig = ec_sign_der_to_raw_signature(kms_sign_resp, _curve())
-    return (_jwt_payload + b"." + base64url_encode(_raw_sig)).decode("ascii")
+    return (_jwt_payload.encode("ascii") + b"." + base64url_encode(_raw_sig)).decode(
+        "ascii"
+    )

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -74,6 +74,13 @@ def compose_unsigned_jwt_for_aws_kms_sign(
     we use pyJWT's infra to create an JWT and then strip away the signature
     to get the raw headers+payload.
 
+    NOTE: the returned signing input is meant to be passed to KMS `Sign` as the
+        `Message`. With `MessageType=RAW`, KMS caps `Message` at 4096 bytes; an
+        embedded `x5c` cert chain can push the input past that for long chains.
+        If so, the caller should hash the signing input with the algorithm's
+        digest (SHA-256/384/512) and call `Sign` with `MessageType=DIGEST`.
+        See https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_RequestSyntax.
+
     Raises:
         ValueError
     """

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -1,0 +1,115 @@
+# Copyright 2025 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Support for using AWS KMS to sign the OTA image JWT.
+
+Only support algorithm that supports by the `jwt_utils` module, which is ES* series.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jwt
+
+from .jwt_utils import (
+    JWT_ALG_CURVE_MAPPING,
+    JWTAlgorithm,
+    _StrEnum,
+    ec_sign_der_to_raw_signature,
+)
+
+
+class AWSKMSignAlgorithm(_StrEnum):
+    ECDSA_SHA_256 = "ECDSA_SHA_256"
+    ECDSA_SHA_384 = "ECDSA_SHA_384"
+    ECDSA_SHA_512 = "ECDSA_SHA_512"
+
+
+JWT_ALG_AWS_ALG_MAPPING = {
+    JWTAlgorithm.ES256: AWSKMSignAlgorithm.ECDSA_SHA_256,
+    JWTAlgorithm.ES384: AWSKMSignAlgorithm.ECDSA_SHA_384,
+    JWTAlgorithm.ES512: AWSKMSignAlgorithm.ECDSA_SHA_512,
+}
+"""Mapping between JWT ES* series algorithm to AWS KMS signing algorithm set.
+
+Also see https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_RequestSyntax
+and https://datatracker.ietf.org/doc/html/rfc7518#section-3.4.
+"""
+
+AWS_ALG_JWT_ALG_MAPPING = {v: k for k, v in JWT_ALG_AWS_ALG_MAPPING.items()}
+
+
+def get_aws_sign_alg(jwt_sign_alg: str) -> AWSKMSignAlgorithm:
+    try:
+        return JWT_ALG_AWS_ALG_MAPPING[JWTAlgorithm(jwt_sign_alg)]
+    except ValueError:
+        raise ValueError(f"unsupported or unknown {jwt_sign_alg=}") from None
+    except KeyError:
+        raise ValueError(f"unsupported or unknown {jwt_sign_alg=}") from None
+
+
+def compose_unsigned_jwt_for_aws_kms_sign(
+    payload: dict[str, Any],
+    headers: dict[str, Any] | None = None,
+    *,
+    alg: str,
+) -> tuple[AWSKMSignAlgorithm, str]:
+    """Compose a JWT with only header and payload parts,
+    ready for signing with AWS KMS sign API.
+
+    To simplify the implementation and avoid rebuild the wheel,
+    we use pyJWT's infra to create an JWT and then strip away the signature
+    to get the raw headers+payload.
+
+    Raises:
+        ValueError
+    """
+    # drop the dummy signature, the leftover will become valid input
+    #   for actual JWT signing
+    _aws_alg = get_aws_sign_alg(alg)
+    _raw_payload = jwt.encode(
+        payload=payload,
+        headers=headers,
+        key="DUMMY_KEY",
+        algorithm=alg,
+    ).rsplit(".", 1)[0]
+    return (_aws_alg, _raw_payload)
+
+
+def compose_jwt_from_aws_kms_sign_response(
+    _jwt_payload: bytes, *, kms_sign_resp: bytes, kms_sign_algorithm: str
+) -> bytes:
+    """Compose the complete JWT from JWT payload and AWS KMS signing resp.
+
+    Caller needs to encode the payload and signature beforehand.
+    For the signature part, the caller needs to extract the signature from the
+      full AWS KMS signing response JSON object, and then do BASE64_URL decode to
+      get the raw DER format signature.
+
+    NOTE: we don't do verification over the resp and payload to
+          check whether the signing response is actually for the
+          jwt_payload, we have no way to know that anyway(we don't
+          know the private key).
+    """
+    try:
+        _kms_sign_alg = AWSKMSignAlgorithm(kms_sign_algorithm)
+    except ValueError:
+        raise ValueError(f"unsupported or invalid {kms_sign_algorithm=}") from None
+
+    try:
+        _curve = JWT_ALG_CURVE_MAPPING[AWS_ALG_JWT_ALG_MAPPING[_kms_sign_alg]]
+    except KeyError as e:
+        raise ValueError(f"unsupported or invalid algorithm: {e!r}") from None
+
+    return _jwt_payload + b"." + ec_sign_der_to_raw_signature(kms_sign_resp, _curve)

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -33,16 +33,16 @@ from .jwt_utils import (
 )
 
 
-class AWSKMSignAlgorithm(StrEnum):
+class AWSKMSSignAlgorithm(StrEnum):
     ECDSA_SHA_256 = "ECDSA_SHA_256"
     ECDSA_SHA_384 = "ECDSA_SHA_384"
     ECDSA_SHA_512 = "ECDSA_SHA_512"
 
 
 JWT_ALG_AWS_ALG_MAPPING = {
-    JWTAlgorithm.ES256: AWSKMSignAlgorithm.ECDSA_SHA_256,
-    JWTAlgorithm.ES384: AWSKMSignAlgorithm.ECDSA_SHA_384,
-    JWTAlgorithm.ES512: AWSKMSignAlgorithm.ECDSA_SHA_512,
+    JWTAlgorithm.ES256: AWSKMSSignAlgorithm.ECDSA_SHA_256,
+    JWTAlgorithm.ES384: AWSKMSSignAlgorithm.ECDSA_SHA_384,
+    JWTAlgorithm.ES512: AWSKMSSignAlgorithm.ECDSA_SHA_512,
 }
 """Mapping between JWT ES* series algorithm to AWS KMS signing algorithm set.
 
@@ -53,7 +53,7 @@ and https://datatracker.ietf.org/doc/html/rfc7518#section-3.4.
 AWS_ALG_JWT_ALG_MAPPING = {v: k for k, v in JWT_ALG_AWS_ALG_MAPPING.items()}
 
 
-def get_aws_sign_alg(jwt_sign_alg: str) -> AWSKMSignAlgorithm:
+def get_aws_sign_alg(jwt_sign_alg: str) -> AWSKMSSignAlgorithm:
     try:
         return JWT_ALG_AWS_ALG_MAPPING[JWTAlgorithm(jwt_sign_alg)]
     except (ValueError, KeyError):
@@ -65,7 +65,7 @@ def compose_unsigned_jwt_for_aws_kms_sign(
     headers: dict[str, Any] | None = None,
     *,
     alg: str,
-) -> tuple[AWSKMSignAlgorithm, str]:
+) -> tuple[AWSKMSSignAlgorithm, str]:
     """Compose a JWT with only header and payload parts,
     ready for signing with AWS KMS sign API.
 
@@ -114,7 +114,7 @@ def compose_jwt_from_aws_kms_sign_response(
         given jwt_payload - we can't, as we don't have the private key.
     """
     try:
-        _kms_sign_alg = AWSKMSignAlgorithm(kms_sign_algorithm)
+        _kms_sign_alg = AWSKMSSignAlgorithm(kms_sign_algorithm)
         _curve = JWT_ALG_CURVE_MAPPING[AWS_ALG_JWT_ALG_MAPPING[_kms_sign_alg]]
     except (ValueError, KeyError):
         raise ValueError(f"unsupported or invalid {kms_sign_algorithm=}") from None

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -24,15 +24,16 @@ import jwt
 from cryptography.hazmat.primitives.asymmetric import ec
 from jwt.utils import base64url_encode
 
+from ota_image_libs.common import StrEnum
+
 from .jwt_utils import (
     JWT_ALG_CURVE_MAPPING,
     JWTAlgorithm,
-    _StrEnum,
     ec_sign_der_to_raw_signature,
 )
 
 
-class AWSKMSignAlgorithm(_StrEnum):
+class AWSKMSignAlgorithm(StrEnum):
     ECDSA_SHA_256 = "ECDSA_SHA_256"
     ECDSA_SHA_384 = "ECDSA_SHA_384"
     ECDSA_SHA_512 = "ECDSA_SHA_512"

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Support for using AWS KMS to sign the OTA image JWT.
 
-Only support algorithm that supports by the `jwt_utils` module, which is ES* series.
+Only support algorithm that supported by the `jwt_utils` module, which are ES* series.
 """
 
 from __future__ import annotations

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import jwt
 from cryptography.hazmat.primitives.asymmetric import ec
+from jwt.utils import base64url_encode
 
 from .jwt_utils import (
     JWT_ALG_CURVE_MAPPING,
@@ -111,4 +112,5 @@ def compose_jwt_from_aws_kms_sign_response(
     except KeyError as e:
         raise ValueError(f"unsupported or invalid algorithm: {e!r}") from None
 
-    return _jwt_payload + b"." + ec_sign_der_to_raw_signature(kms_sign_resp, _curve)
+    _raw_sig = ec_sign_der_to_raw_signature(kms_sign_resp, _curve)
+    return _jwt_payload + b"." + base64url_encode(_raw_sig)

--- a/src/ota_image_libs/_crypto/aws_kms.py
+++ b/src/ota_image_libs/_crypto/aws_kms.py
@@ -95,17 +95,22 @@ def compose_unsigned_jwt_for_aws_kms_sign(
 def compose_jwt_from_aws_kms_sign_response(
     _jwt_payload: bytes, *, kms_sign_resp: bytes, kms_sign_algorithm: str
 ) -> str:
-    """Compose the complete JWT from JWT payload and AWS KMS signing resp.
+    """Compose the complete signed JWT from the signing input and a KMS Sign response.
 
-    Caller needs to encode the payload and signature beforehand.
-    For the signature part, the caller needs to extract the signature from the
-      full AWS KMS signing response JSON object, and then do BASE64_URL decode to
-      get the raw DER format signature.
+    Args:
+        _jwt_payload: the JWT signing input (``header.payload``) as bytes.
+        kms_sign_resp: the raw DER-encoded ECDSA signature taken from the KMS
+            ``Sign`` response's ``Signature`` field.
+        kms_sign_algorithm: the response's ``SigningAlgorithm`` (e.g. ``ECDSA_SHA_256``).
 
-    NOTE: we don't do verification over the resp and payload to
-          check whether the signing response is actually for the
-          jwt_payload, we have no way to know that anyway(we don't
-          know the private key).
+    Returns:
+        The complete JWT ``header.payload.signature`` as a str.
+
+    Raises:
+        ValueError: if ``kms_sign_algorithm`` is unsupported or invalid.
+
+    NOTE: we don't verify that the signing response actually corresponds to the
+        given jwt_payload - we can't, as we don't have the private key.
     """
     try:
         _kms_sign_alg = AWSKMSignAlgorithm(kms_sign_algorithm)

--- a/src/ota_image_libs/_crypto/jwt_utils.py
+++ b/src/ota_image_libs/_crypto/jwt_utils.py
@@ -94,4 +94,4 @@ def get_unverified_jwt_headers(token: str) -> dict[str, Any]:
     This is for caller get the x5c header, perform the sign cert verification,
         and then use verified sign cert's pubkey to verify the JWS signature.
     """
-    return jwt.get_unverified_header(token)  # noqa
+    return jwt.get_unverified_header(token)  # noqa: S5659

--- a/src/ota_image_libs/_crypto/jwt_utils.py
+++ b/src/ota_image_libs/_crypto/jwt_utils.py
@@ -17,6 +17,39 @@ from __future__ import annotations
 from typing import Any
 
 import jwt
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
+from jwt.utils import der_to_raw_signature
+
+JWT_ALG_AWS_ALG_MAPPING = {
+    # JWT alg: AWS sign algorithm
+    "ES256": "ECDSA_SHA_256",
+    "ES384": "ECDSA_SHA_384",
+    "ES512": "ECDSA_SHA_512",
+}
+"""Mapping between JWT ES* series algorithm to AWS KMS signing algorithm set.
+
+Also see https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_RequestSyntax
+and https://datatracker.ietf.org/doc/html/rfc7518#section-3.4.
+"""
+
+AWS_ALG_JWT_ALG_MAPPING = {v: k for k, v in JWT_ALG_AWS_ALG_MAPPING.items()}
+
+
+def ec_sign_der_to_raw_signature(der_sig: bytes, ec_curve: EllipticCurve):
+    """Util to convert a DER-format ECDSA sign to JWT signature format.
+
+    JWT expects the signature to be in "raw" format, see https://datatracker.ietf.org/doc/html/rfc7518#section-3.4.
+    ECDSA signing request response from AWS KMS sign is in DER format, so this convert is required.
+    See https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_ResponseSyntax.
+    """
+    return der_to_raw_signature(der_sig, ec_curve)
+
+
+def get_aws_sign_alg(jwt_sign_alg: str) -> str:
+    try:
+        return JWT_ALG_AWS_ALG_MAPPING[jwt_sign_alg]
+    except KeyError:
+        raise ValueError(f"unsupported {jwt_sign_alg=}") from None
 
 
 def compose_jwt(

--- a/src/ota_image_libs/_crypto/jwt_utils.py
+++ b/src/ota_image_libs/_crypto/jwt_utils.py
@@ -41,7 +41,7 @@ class JWTAlgorithm(_StrEnum):
     ES512 = "ES512"
 
 
-JWT_ALG_CURVE_MAPPING = {
+JWT_ALG_CURVE_MAPPING: dict[JWTAlgorithm, type[EllipticCurve]] = {
     JWTAlgorithm.ES256: SECP256R1,
     JWTAlgorithm.ES384: SECP384R1,
     JWTAlgorithm.ES512: SECP521R1,

--- a/src/ota_image_libs/_crypto/jwt_utils.py
+++ b/src/ota_image_libs/_crypto/jwt_utils.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from typing import Any
 
 import jwt
@@ -26,16 +25,10 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
 )
 from jwt.utils import der_to_raw_signature
 
-
-class _StrEnum(str, Enum):
-    def __str__(self) -> str:
-        """
-        NOTE: mimic the new StrEnum's behavior.
-        """
-        return self.value
+from ota_image_libs.common import StrEnum
 
 
-class JWTAlgorithm(_StrEnum):
+class JWTAlgorithm(StrEnum):
     ES256 = "ES256"
     ES384 = "ES384"
     ES512 = "ES512"

--- a/src/ota_image_libs/_crypto/jwt_utils.py
+++ b/src/ota_image_libs/_crypto/jwt_utils.py
@@ -14,28 +14,41 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 import jwt
-from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    SECP256R1,
+    SECP384R1,
+    SECP521R1,
+    EllipticCurve,
+)
 from jwt.utils import der_to_raw_signature
 
-JWT_ALG_AWS_ALG_MAPPING = {
-    # JWT alg: AWS sign algorithm
-    "ES256": "ECDSA_SHA_256",
-    "ES384": "ECDSA_SHA_384",
-    "ES512": "ECDSA_SHA_512",
+
+class _StrEnum(str, Enum):
+    def __str__(self) -> str:
+        """
+        NOTE: mimic the new StrEnum's behavior.
+        """
+        return self.value
+
+
+class JWTAlgorithm(_StrEnum):
+    ES256 = "ES256"
+    ES384 = "ES384"
+    ES512 = "ES512"
+
+
+JWT_ALG_CURVE_MAPPING = {
+    JWTAlgorithm.ES256: SECP256R1,
+    JWTAlgorithm.ES384: SECP384R1,
+    JWTAlgorithm.ES512: SECP521R1,
 }
-"""Mapping between JWT ES* series algorithm to AWS KMS signing algorithm set.
-
-Also see https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_RequestSyntax
-and https://datatracker.ietf.org/doc/html/rfc7518#section-3.4.
-"""
-
-AWS_ALG_JWT_ALG_MAPPING = {v: k for k, v in JWT_ALG_AWS_ALG_MAPPING.items()}
 
 
-def ec_sign_der_to_raw_signature(der_sig: bytes, ec_curve: EllipticCurve):
+def ec_sign_der_to_raw_signature(der_sig: bytes, ec_curve: EllipticCurve) -> bytes:
     """Util to convert a DER-format ECDSA sign to JWT signature format.
 
     JWT expects the signature to be in "raw" format, see https://datatracker.ietf.org/doc/html/rfc7518#section-3.4.
@@ -43,13 +56,6 @@ def ec_sign_der_to_raw_signature(der_sig: bytes, ec_curve: EllipticCurve):
     See https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_ResponseSyntax.
     """
     return der_to_raw_signature(der_sig, ec_curve)
-
-
-def get_aws_sign_alg(jwt_sign_alg: str) -> str:
-    try:
-        return JWT_ALG_AWS_ALG_MAPPING[jwt_sign_alg]
-    except KeyError:
-        raise ValueError(f"unsupported {jwt_sign_alg=}") from None
 
 
 def compose_jwt(
@@ -82,12 +88,10 @@ def get_verified_jwt_payload(
     )
 
 
-def get_unverified_jwt_headers(
-    token: str,
-) -> dict[str, Any]:
+def get_unverified_jwt_headers(token: str) -> dict[str, Any]:
     """Parse the input JWT and return its headers.
 
     This is for caller get the x5c header, perform the sign cert verification,
         and then use verified sign cert's pubkey to verify the JWS signature.
     """
-    return jwt.get_unverified_header(token)
+    return jwt.get_unverified_header(token)  # noqa

--- a/src/ota_image_libs/common/__init__.py
+++ b/src/ota_image_libs/common/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Common shared utils and libs for parsing and generating OTA images metadata."""
 
-from ._common import tmp_fname
+from ._common import StrEnum, tmp_fname
 from .metafile_base import MetaFileBase, MetaFileDescriptor
 from .model_fields import ConstFieldWithAltMeta
 from .model_spec import (
@@ -35,4 +35,5 @@ __all__ = [
     "Sha256Digest",
     "ConstFieldWithAltMeta",
     "tmp_fname",
+    "StrEnum",
 ]

--- a/src/ota_image_libs/common/_common.py
+++ b/src/ota_image_libs/common/_common.py
@@ -15,11 +15,28 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any
 
 from pydantic import ValidationInfo
 
 DEFAULT_TMP_FNAME_PREFIX = "tmp"
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """
+        NOTE: mimic the new StrEnum's behavior.
+        """
+
+        def __str__(self) -> str:
+            return self.value
+
+        def __format__(self, format_spec: str) -> str:
+            return str.__format__(self, format_spec)
 
 
 def tmp_fname(

--- a/src/ota_image_libs/v1/index_jwt/utils.py
+++ b/src/ota_image_libs/v1/index_jwt/utils.py
@@ -28,6 +28,10 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
 )
 
+from ota_image_libs._crypto.aws_kms import (
+    AWSKMSSignAlgorithm,
+    compose_unsigned_jwt_for_aws_kms_sign,
+)
 from ota_image_libs._crypto.jwt_utils import (
     compose_jwt,
     get_unverified_jwt_headers,
@@ -86,6 +90,43 @@ def compose_index_jwt(
             encryption_algorithm=NoEncryption(),
         ),
         alg=ALLOWED_JWT_ALG,
+    )
+
+
+def compose_unsigned_index_jwt_for_aws_kms_sign(
+    index_descriptor: ImageIndex.Descriptor, *, sign_cert_chain: X5cX509CertChain
+) -> tuple[AWSKMSSignAlgorithm, str]:
+    """
+    Same as `compose_index_jwt`, but return a raw non-signed index.jwt.
+
+    To simplify the implementation and avoid rebuilding the wheel, the JWT is
+    created with pyJWT using a throwaway key, and the signature is then stripped
+    away to get the raw `header.payload` part.
+
+    Args:
+        index_descriptor (ImageIndex.Descriptor): The descriptor of the
+            index.json to be signed.
+        sign_cert_chain (X5cX509CertChain): The certificate chain used for
+            signing, embedded into the JWT header as the `x5c` field.
+
+    Raises:
+        ValueError: If the configured JWT algorithm has no corresponding AWS KMS
+            signing algorithm.
+
+    Returns:
+        tuple[AWSKMSSignAlgorithm, str]: A two-tuple of the AWS KMS signing
+            algorithm to pass to the KMS `Sign` API, and the unsigned signing
+            input (`header.payload`) to be signed.
+    """
+    jwt_alg = ALLOWED_JWT_ALG
+    claims_dict = IndexJWTClaims(
+        iat=int(time.time()),
+        image_index=index_descriptor,
+    ).model_dump(by_alias=True, exclude_none=True)
+    extra_headers = {X5C_FNAME: sign_cert_chain.serializer()}
+
+    return compose_unsigned_jwt_for_aws_kms_sign(
+        payload=claims_dict, headers=extra_headers, alg=jwt_alg
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import base64
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
@@ -28,6 +29,7 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePrivateKey,
     EllipticCurvePublicKey,
 )
+from cryptography.hazmat.primitives.hashes import HashAlgorithm
 from cryptography.x509 import Certificate
 from cryptography.x509.oid import NameOID
 
@@ -58,6 +60,63 @@ def ecdsa_keypair() -> tuple[EllipticCurvePrivateKey, EllipticCurvePublicKey]:
     private_key = ec.generate_private_key(ec.SECP256R1())
     public_key = private_key.public_key()
     return private_key, public_key
+
+
+#
+# ------------ Shared JWT / AWS KMS signing test helpers ------------ #
+#
+# A representative KMS key ARN; only its shape matters for these tests.
+FAKE_KMS_KEY_ID = (
+    "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+)
+
+
+def b64url_decode(segment: str | bytes) -> bytes:
+    """base64url-decode a JWS segment, restoring the stripped padding."""
+    raw = segment.encode("ascii") if isinstance(segment, str) else segment
+    raw += b"=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode(raw)
+
+
+def ecdsa_der_sign(
+    priv_key: EllipticCurvePrivateKey, message: bytes, digest: HashAlgorithm
+) -> bytes:
+    """Produce a DER-encoded ECDSA signature over ``message``.
+
+    AWS KMS `Sign` with `MessageType=RAW` hashes the message with the signing
+    algorithm's digest and returns the signature DER-encoded (ANSI X9.62-2005 /
+    RFC 3279 section 2.2.3); cryptography's ``sign(msg, ECDSA(hash))`` does the
+    same, so it stands in for the KMS crypto here.
+    """
+    return priv_key.sign(message, ec.ECDSA(digest))
+
+
+def simulate_kms_sign_response(
+    priv_key: EllipticCurvePrivateKey,
+    message: bytes,
+    *,
+    digest: HashAlgorithm,
+    signing_algorithm: str,
+    key_id: str = FAKE_KMS_KEY_ID,
+) -> dict[str, str]:
+    """Build a self-generated AWS KMS `Sign` response (no live AWS needed).
+
+    Mirrors the documented response syntax::
+
+        {"KeyId": str, "Signature": blob, "SigningAlgorithm": str}
+
+    On the JSON/HTTP wire the `Signature` blob is standard-base64 encoded (boto3
+    hands it back already decoded to ``bytes``); we model the wire form here so
+    the test exercises the same decode a real caller must perform.
+
+    See https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_ResponseSyntax
+    """
+    der_sig = ecdsa_der_sign(priv_key, message, digest)
+    return {
+        "KeyId": key_id,
+        "Signature": base64.b64encode(der_sig).decode("ascii"),
+        "SigningAlgorithm": signing_algorithm,
+    }
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_aws_kms.py
+++ b/tests/test_aws_kms.py
@@ -194,7 +194,7 @@ class TestComposeJwtFromAwsKmsSignResponse:
         der_sig = _ecdsa_der_sign(priv, b"header.payload", digest())
 
         token = compose_jwt_from_aws_kms_sign_response(
-            b"header.payload", kms_sign_resp=der_sig, kms_sign_algorithm=aws_alg
+            "header.payload", kms_sign_resp=der_sig, kms_sign_algorithm=aws_alg
         )
 
         assert isinstance(token, str)
@@ -209,7 +209,7 @@ class TestComposeJwtFromAwsKmsSignResponse:
     def test_rejects_unsupported_kms_algorithm(self, bad_alg: str):
         with pytest.raises(ValueError):
             compose_jwt_from_aws_kms_sign_response(
-                b"header.payload", kms_sign_resp=b"\x00", kms_sign_algorithm=bad_alg
+                "header.payload", kms_sign_resp=b"\x00", kms_sign_algorithm=bad_alg
             )
 
 
@@ -254,7 +254,7 @@ class TestAwsKmsSigningRoundTrip:
         #    and compose the complete JWT
         der_sig = base64.b64decode(kms_resp["Signature"])
         token = compose_jwt_from_aws_kms_sign_response(
-            signing_input.encode(),
+            signing_input,
             kms_sign_resp=der_sig,
             kms_sign_algorithm=kms_resp["SigningAlgorithm"],
         )
@@ -284,7 +284,7 @@ class TestAwsKmsSigningRoundTrip:
             signing_algorithm="ECDSA_SHA_256",
         )
         token = compose_jwt_from_aws_kms_sign_response(
-            signing_input.encode(),
+            signing_input,
             kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
             kms_sign_algorithm=kms_resp["SigningAlgorithm"],
         )
@@ -320,7 +320,7 @@ class TestAwsKmsSigningRoundTrip:
             signing_algorithm="ECDSA_SHA_256",
         )
         token = compose_jwt_from_aws_kms_sign_response(
-            signing_input.encode(),
+            signing_input,
             kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
             kms_sign_algorithm=kms_resp["SigningAlgorithm"],
         )
@@ -361,7 +361,7 @@ class TestAwsKmsSigningWithIndexJwtReadPath:
             signing_algorithm="ECDSA_SHA_256",
         )
         token = compose_jwt_from_aws_kms_sign_response(
-            signing_input.encode(),
+            signing_input,
             kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
             kms_sign_algorithm=kms_resp["SigningAlgorithm"],
         )

--- a/tests/test_aws_kms.py
+++ b/tests/test_aws_kms.py
@@ -21,10 +21,7 @@ import jwt
 import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.asymmetric.ec import (
-    EllipticCurve,
-    EllipticCurvePrivateKey,
-)
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 from cryptography.hazmat.primitives.hashes import HashAlgorithm
 from jwt.exceptions import InvalidSignatureError
 
@@ -37,6 +34,11 @@ from ota_image_libs._crypto.aws_kms import (
     get_aws_sign_alg,
 )
 from ota_image_libs._crypto.jwt_utils import JWTAlgorithm, get_verified_jwt_payload
+from tests.conftest import (
+    b64url_decode,
+    ecdsa_der_sign,
+    simulate_kms_sign_response,
+)
 
 # (jwt_alg, aws_alg, curve, hash, raw r||s signature length in bytes)
 # raw length is 2 * ceil(key_size / 8): P-256 -> 64, P-384 -> 96, P-521 -> 132.
@@ -45,59 +47,6 @@ ES_CURVE_CASES = [
     ("ES384", "ECDSA_SHA_384", ec.SECP384R1, hashes.SHA384, 96),
     ("ES512", "ECDSA_SHA_512", ec.SECP521R1, hashes.SHA512, 132),
 ]
-
-
-def _b64url_decode(segment: bytes) -> bytes:
-    """base64url-decode a JWS segment, restoring the stripped padding."""
-    pad = b"=" * (-len(segment) % 4)
-    return base64.urlsafe_b64decode(segment + pad)
-
-
-# A representative KMS key ARN; only its shape matters for these tests.
-_FAKE_KEY_ID = (
-    "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-)
-
-
-def _ecdsa_der_sign(
-    priv_key: EllipticCurvePrivateKey, message: bytes, digest: HashAlgorithm
-) -> bytes:
-    """Produce a DER-encoded ECDSA signature over ``message``.
-
-    AWS KMS `Sign` with `MessageType=RAW` hashes the message with the signing
-    algorithm's digest and returns the signature DER-encoded (ANSI X9.62-2005 /
-    RFC 3279 section 2.2.3); cryptography's ``sign(msg, ECDSA(hash))`` does the
-    same, so it stands in for the KMS crypto here.
-    """
-    return priv_key.sign(message, ec.ECDSA(digest))
-
-
-def _simulate_kms_sign_response(
-    priv_key: EllipticCurvePrivateKey,
-    message: bytes,
-    *,
-    digest: HashAlgorithm,
-    signing_algorithm: str,
-    key_id: str = _FAKE_KEY_ID,
-) -> dict[str, str]:
-    """Build a self-generated AWS KMS `Sign` response (no live AWS needed).
-
-    Mirrors the documented response syntax::
-
-        {"KeyId": str, "Signature": blob, "SigningAlgorithm": str}
-
-    On the JSON/HTTP wire the `Signature` blob is standard-base64 encoded (boto3
-    hands it back already decoded to ``bytes``); we model the wire form here so
-    the test exercises the same decode a real caller must perform.
-
-    See https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_ResponseSyntax
-    """
-    der_sig = _ecdsa_der_sign(priv_key, message, digest)
-    return {
-        "KeyId": key_id,
-        "Signature": base64.b64encode(der_sig).decode("ascii"),
-        "SigningAlgorithm": signing_algorithm,
-    }
 
 
 #
@@ -155,7 +104,7 @@ class TestComposeUnsignedJwtForAwsKmsSign:
             {"sub": "img"}, {"kid": "key-1"}, alg="ES256"
         )
         header_seg = signing_input.split(".", 1)[0]
-        header = json.loads(_b64url_decode(header_seg.encode()))
+        header = json.loads(b64url_decode(header_seg.encode()))
         assert header["alg"] == "ES256"
         assert header["typ"] == "JWT"
         assert header["kid"] == "key-1"
@@ -164,7 +113,7 @@ class TestComposeUnsignedJwtForAwsKmsSign:
         payload = {"sub": "img", "iat": 123, "nested": {"a": 1}}
         _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(payload, alg="ES256")
         payload_seg = signing_input.split(".")[1]
-        assert json.loads(_b64url_decode(payload_seg.encode())) == payload
+        assert json.loads(b64url_decode(payload_seg.encode())) == payload
 
     def test_works_without_extra_headers(self):
         aws_alg, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
@@ -191,7 +140,7 @@ class TestComposeJwtFromAwsKmsSignResponse:
     ):
         """The third segment must be base64url(raw r||s), not raw DER bytes."""
         priv = ec.generate_private_key(curve())
-        der_sig = _ecdsa_der_sign(priv, b"header.payload", digest())
+        der_sig = ecdsa_der_sign(priv, b"header.payload", digest())
 
         token = compose_jwt_from_aws_kms_sign_response(
             "header.payload", kms_sign_resp=der_sig, kms_sign_algorithm=aws_alg
@@ -201,9 +150,9 @@ class TestComposeJwtFromAwsKmsSignResponse:
         assert token.count(".") == 2
         sig_seg = token.rsplit(".", 1)[1].encode()
         # must be valid (padding-less) base64url, i.e. no raw binary leaked through
-        assert sig_seg == base64.urlsafe_b64encode(_b64url_decode(sig_seg)).rstrip(b"=")
+        assert sig_seg == base64.urlsafe_b64encode(b64url_decode(sig_seg)).rstrip(b"=")
         # decoded signature is the fixed-length raw r||s form JWS expects
-        assert len(_b64url_decode(sig_seg)) == raw_len
+        assert len(b64url_decode(sig_seg)) == raw_len
 
     @pytest.mark.parametrize("bad_alg", ["ECDSA_SHA_128", "RS256", "", "garbage"])
     def test_rejects_unsupported_kms_algorithm(self, bad_alg: str):
@@ -241,7 +190,7 @@ class TestAwsKmsSigningRoundTrip:
         assert str(composed_aws_alg) == aws_alg
 
         # 2. AWS KMS Sign: self-generate a response shaped like the real API
-        kms_resp = _simulate_kms_sign_response(
+        kms_resp = simulate_kms_sign_response(
             priv,
             signing_input.encode(),
             digest=digest(),
@@ -277,7 +226,7 @@ class TestAwsKmsSigningRoundTrip:
         _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
             {"sub": "img"}, {"typ": "JWT"}, alg="ES256"
         )
-        kms_resp = _simulate_kms_sign_response(
+        kms_resp = simulate_kms_sign_response(
             priv,
             signing_input.encode(),
             digest=hashes.SHA256(),
@@ -313,7 +262,7 @@ class TestAwsKmsSigningRoundTrip:
         _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
             {"sub": "img"}, {"typ": "JWT"}, alg="ES256"
         )
-        kms_resp = _simulate_kms_sign_response(
+        kms_resp = simulate_kms_sign_response(
             priv,
             signing_input.encode(),
             digest=hashes.SHA256(),
@@ -354,7 +303,7 @@ class TestAwsKmsSigningWithIndexJwtReadPath:
             headers,
             alg="ES256",
         )
-        kms_resp = _simulate_kms_sign_response(
+        kms_resp = simulate_kms_sign_response(
             ee_key,
             signing_input.encode(),
             digest=hashes.SHA256(),

--- a/tests/test_aws_kms.py
+++ b/tests/test_aws_kms.py
@@ -197,9 +197,9 @@ class TestComposeJwtFromAwsKmsSignResponse:
             b"header.payload", kms_sign_resp=der_sig, kms_sign_algorithm=aws_alg
         )
 
-        assert isinstance(token, bytes)
-        assert token.count(b".") == 2
-        sig_seg = token.rsplit(b".", 1)[1]
+        assert isinstance(token, str)
+        assert token.count(".") == 2
+        sig_seg = token.rsplit(".", 1)[1].encode()
         # must be valid (padding-less) base64url, i.e. no raw binary leaked through
         assert sig_seg == base64.urlsafe_b64encode(_b64url_decode(sig_seg)).rstrip(b"=")
         # decoded signature is the fixed-length raw r||s form JWS expects
@@ -263,9 +263,7 @@ class TestAwsKmsSigningRoundTrip:
         assert jwt.decode(token, key=pub_pem, algorithms=[jwt_alg]) == payload
         # 4b. verifiable through the library's own verification helper
         assert (
-            get_verified_jwt_payload(
-                token.decode(), pub_key=pub_pem, allowed_algs=[jwt_alg]
-            )
+            get_verified_jwt_payload(token, pub_key=pub_pem, allowed_algs=[jwt_alg])
             == payload
         )
 
@@ -292,9 +290,11 @@ class TestAwsKmsSigningRoundTrip:
         )
 
         # flip the payload segment to a different (validly-encoded) value
-        header_seg, _, sig_seg = token.split(b".")
-        forged_payload = base64.urlsafe_b64encode(b'{"sub": "evil"}').rstrip(b"=")
-        forged = header_seg + b"." + forged_payload + b"." + sig_seg
+        header_seg, _, sig_seg = token.split(".")
+        forged_payload = (
+            base64.urlsafe_b64encode(b'{"sub": "evil"}').rstrip(b"=").decode("ascii")
+        )
+        forged = header_seg + "." + forged_payload + "." + sig_seg
 
         with pytest.raises(InvalidSignatureError):
             jwt.decode(forged, key=pub_pem, algorithms=["ES256"])
@@ -364,7 +364,7 @@ class TestAwsKmsSigningWithIndexJwtReadPath:
             signing_input.encode(),
             kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
             kms_sign_algorithm=kms_resp["SigningAlgorithm"],
-        ).decode()
+        )
 
         # the existing read path extracts the x5c chain and verifies the signature
         extracted_chain = get_index_jwt_sign_cert_chain(token)

--- a/tests/test_aws_kms.py
+++ b/tests/test_aws_kms.py
@@ -31,7 +31,7 @@ from jwt.exceptions import InvalidSignatureError
 from ota_image_libs._crypto.aws_kms import (
     AWS_ALG_JWT_ALG_MAPPING,
     JWT_ALG_AWS_ALG_MAPPING,
-    AWSKMSignAlgorithm,
+    AWSKMSSignAlgorithm,
     compose_jwt_from_aws_kms_sign_response,
     compose_unsigned_jwt_for_aws_kms_sign,
     get_aws_sign_alg,
@@ -110,7 +110,7 @@ class TestGetAwsSignAlg:
     )
     def test_maps_each_es_alg(self, jwt_alg: str, expected_aws_alg: str):
         result = get_aws_sign_alg(jwt_alg)
-        assert isinstance(result, AWSKMSignAlgorithm)
+        assert isinstance(result, AWSKMSSignAlgorithm)
         assert str(result) == expected_aws_alg
 
     @pytest.mark.parametrize("bad_alg", ["RS256", "HS256", "ES128", "", "garbage"])
@@ -144,7 +144,7 @@ class TestComposeUnsignedJwtForAwsKmsSign:
         aws_alg, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
             {"sub": "img"}, {"typ": "JWT"}, alg=jwt_alg
         )
-        assert isinstance(aws_alg, AWSKMSignAlgorithm)
+        assert isinstance(aws_alg, AWSKMSSignAlgorithm)
         assert str(aws_alg) == expected_aws_alg
         # only header + payload, no signature segment yet
         assert isinstance(signing_input, str)

--- a/tests/test_aws_kms.py
+++ b/tests/test_aws_kms.py
@@ -1,0 +1,375 @@
+# Copyright 2025 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import base64
+import json
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    EllipticCurve,
+    EllipticCurvePrivateKey,
+)
+from cryptography.hazmat.primitives.hashes import HashAlgorithm
+from jwt.exceptions import InvalidSignatureError
+
+from ota_image_libs._crypto.aws_kms import (
+    AWS_ALG_JWT_ALG_MAPPING,
+    JWT_ALG_AWS_ALG_MAPPING,
+    AWSKMSignAlgorithm,
+    compose_jwt_from_aws_kms_sign_response,
+    compose_unsigned_jwt_for_aws_kms_sign,
+    get_aws_sign_alg,
+)
+from ota_image_libs._crypto.jwt_utils import JWTAlgorithm, get_verified_jwt_payload
+
+# (jwt_alg, aws_alg, curve, hash, raw r||s signature length in bytes)
+# raw length is 2 * ceil(key_size / 8): P-256 -> 64, P-384 -> 96, P-521 -> 132.
+ES_CURVE_CASES = [
+    ("ES256", "ECDSA_SHA_256", ec.SECP256R1, hashes.SHA256, 64),
+    ("ES384", "ECDSA_SHA_384", ec.SECP384R1, hashes.SHA384, 96),
+    ("ES512", "ECDSA_SHA_512", ec.SECP521R1, hashes.SHA512, 132),
+]
+
+
+def _b64url_decode(segment: bytes) -> bytes:
+    """base64url-decode a JWS segment, restoring the stripped padding."""
+    pad = b"=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + pad)
+
+
+# A representative KMS key ARN; only its shape matters for these tests.
+_FAKE_KEY_ID = (
+    "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+)
+
+
+def _ecdsa_der_sign(
+    priv_key: EllipticCurvePrivateKey, message: bytes, digest: HashAlgorithm
+) -> bytes:
+    """Produce a DER-encoded ECDSA signature over ``message``.
+
+    AWS KMS `Sign` with `MessageType=RAW` hashes the message with the signing
+    algorithm's digest and returns the signature DER-encoded (ANSI X9.62-2005 /
+    RFC 3279 section 2.2.3); cryptography's ``sign(msg, ECDSA(hash))`` does the
+    same, so it stands in for the KMS crypto here.
+    """
+    return priv_key.sign(message, ec.ECDSA(digest))
+
+
+def _simulate_kms_sign_response(
+    priv_key: EllipticCurvePrivateKey,
+    message: bytes,
+    *,
+    digest: HashAlgorithm,
+    signing_algorithm: str,
+    key_id: str = _FAKE_KEY_ID,
+) -> dict[str, str]:
+    """Build a self-generated AWS KMS `Sign` response (no live AWS needed).
+
+    Mirrors the documented response syntax::
+
+        {"KeyId": str, "Signature": blob, "SigningAlgorithm": str}
+
+    On the JSON/HTTP wire the `Signature` blob is standard-base64 encoded (boto3
+    hands it back already decoded to ``bytes``); we model the wire form here so
+    the test exercises the same decode a real caller must perform.
+
+    See https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#API_Sign_ResponseSyntax
+    """
+    der_sig = _ecdsa_der_sign(priv_key, message, digest)
+    return {
+        "KeyId": key_id,
+        "Signature": base64.b64encode(der_sig).decode("ascii"),
+        "SigningAlgorithm": signing_algorithm,
+    }
+
+
+#
+# ------------ Unit tests ------------ #
+#
+class TestGetAwsSignAlg:
+    @pytest.mark.parametrize(
+        "jwt_alg, expected_aws_alg",
+        [(jwt_alg, aws_alg) for jwt_alg, aws_alg, *_ in ES_CURVE_CASES],
+    )
+    def test_maps_each_es_alg(self, jwt_alg: str, expected_aws_alg: str):
+        result = get_aws_sign_alg(jwt_alg)
+        assert isinstance(result, AWSKMSignAlgorithm)
+        assert str(result) == expected_aws_alg
+
+    @pytest.mark.parametrize("bad_alg", ["RS256", "HS256", "ES128", "", "garbage"])
+    def test_rejects_unsupported_alg(self, bad_alg: str):
+        with pytest.raises(ValueError):
+            get_aws_sign_alg(bad_alg)
+
+
+class TestAlgorithmMappings:
+    def test_jwt_aws_mapping_covers_all_jwt_algorithms(self):
+        """Every JWTAlgorithm member must have a KMS counterpart."""
+        assert set(JWT_ALG_AWS_ALG_MAPPING) == set(JWTAlgorithm)
+
+    def test_aws_mapping_is_inverse_of_jwt_mapping(self):
+        assert AWS_ALG_JWT_ALG_MAPPING == {
+            v: k for k, v in JWT_ALG_AWS_ALG_MAPPING.items()
+        }
+        # round-trips both ways
+        for jwt_alg, aws_alg in JWT_ALG_AWS_ALG_MAPPING.items():
+            assert AWS_ALG_JWT_ALG_MAPPING[aws_alg] == jwt_alg
+
+
+class TestComposeUnsignedJwtForAwsKmsSign:
+    @pytest.mark.parametrize(
+        "jwt_alg, expected_aws_alg",
+        [(jwt_alg, aws_alg) for jwt_alg, aws_alg, *_ in ES_CURVE_CASES],
+    )
+    def test_returns_aws_alg_and_two_segment_input(
+        self, jwt_alg: str, expected_aws_alg: str
+    ):
+        aws_alg, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            {"sub": "img"}, {"typ": "JWT"}, alg=jwt_alg
+        )
+        assert isinstance(aws_alg, AWSKMSignAlgorithm)
+        assert str(aws_alg) == expected_aws_alg
+        # only header + payload, no signature segment yet
+        assert isinstance(signing_input, str)
+        assert signing_input.count(".") == 1
+
+    def test_header_carries_alg_and_typ_and_merges_custom_headers(self):
+        _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            {"sub": "img"}, {"kid": "key-1"}, alg="ES256"
+        )
+        header_seg = signing_input.split(".", 1)[0]
+        header = json.loads(_b64url_decode(header_seg.encode()))
+        assert header["alg"] == "ES256"
+        assert header["typ"] == "JWT"
+        assert header["kid"] == "key-1"
+
+    def test_payload_round_trips(self):
+        payload = {"sub": "img", "iat": 123, "nested": {"a": 1}}
+        _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(payload, alg="ES256")
+        payload_seg = signing_input.split(".")[1]
+        assert json.loads(_b64url_decode(payload_seg.encode())) == payload
+
+    def test_works_without_extra_headers(self):
+        aws_alg, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            {"sub": "img"}, alg="ES256"
+        )
+        assert str(aws_alg) == "ECDSA_SHA_256"
+        assert signing_input.count(".") == 1
+
+    @pytest.mark.parametrize("bad_alg", ["RS256", "HS256", "nonsense"])
+    def test_rejects_unsupported_alg(self, bad_alg: str):
+        with pytest.raises(ValueError):
+            compose_unsigned_jwt_for_aws_kms_sign({"sub": "img"}, alg=bad_alg)
+
+
+class TestComposeJwtFromAwsKmsSignResponse:
+    @pytest.mark.parametrize("jwt_alg, aws_alg, curve, digest, raw_len", ES_CURVE_CASES)
+    def test_signature_segment_is_base64url_encoded_raw_signature(
+        self,
+        jwt_alg: str,
+        aws_alg: str,
+        curve: type[EllipticCurve],
+        digest: type[HashAlgorithm],
+        raw_len: int,
+    ):
+        """The third segment must be base64url(raw r||s), not raw DER bytes."""
+        priv = ec.generate_private_key(curve())
+        der_sig = _ecdsa_der_sign(priv, b"header.payload", digest())
+
+        token = compose_jwt_from_aws_kms_sign_response(
+            b"header.payload", kms_sign_resp=der_sig, kms_sign_algorithm=aws_alg
+        )
+
+        assert isinstance(token, bytes)
+        assert token.count(b".") == 2
+        sig_seg = token.rsplit(b".", 1)[1]
+        # must be valid (padding-less) base64url, i.e. no raw binary leaked through
+        assert sig_seg == base64.urlsafe_b64encode(_b64url_decode(sig_seg)).rstrip(b"=")
+        # decoded signature is the fixed-length raw r||s form JWS expects
+        assert len(_b64url_decode(sig_seg)) == raw_len
+
+    @pytest.mark.parametrize("bad_alg", ["ECDSA_SHA_128", "RS256", "", "garbage"])
+    def test_rejects_unsupported_kms_algorithm(self, bad_alg: str):
+        with pytest.raises(ValueError):
+            compose_jwt_from_aws_kms_sign_response(
+                b"header.payload", kms_sign_resp=b"\x00", kms_sign_algorithm=bad_alg
+            )
+
+
+#
+# ------------ Integration tests ------------ #
+#
+class TestAwsKmsSigningRoundTrip:
+    @pytest.mark.parametrize("jwt_alg, aws_alg, curve, digest, raw_len", ES_CURVE_CASES)
+    def test_full_sign_and_verify_round_trip(
+        self,
+        jwt_alg: str,
+        aws_alg: str,
+        curve: type[EllipticCurve],
+        digest: type[HashAlgorithm],
+        raw_len: int,
+    ):
+        """Compose unsigned -> KMS sign (simulated) -> compose final -> verify."""
+        priv = ec.generate_private_key(curve())
+        pub_pem = priv.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        payload = {"sub": "img", "iat": 123}
+
+        # 1. compose the unsigned signing input
+        composed_aws_alg, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            payload, {"typ": "JWT"}, alg=jwt_alg
+        )
+        assert str(composed_aws_alg) == aws_alg
+
+        # 2. AWS KMS Sign: self-generate a response shaped like the real API
+        kms_resp = _simulate_kms_sign_response(
+            priv,
+            signing_input.encode(),
+            digest=digest(),
+            signing_algorithm=str(composed_aws_alg),
+        )
+        assert set(kms_resp) == {"KeyId", "Signature", "SigningAlgorithm"}
+
+        # 3. extract the DER signature from the response as a real caller would
+        #    (boto3 returns bytes; from the raw JSON wire it is base64-encoded)
+        #    and compose the complete JWT
+        der_sig = base64.b64decode(kms_resp["Signature"])
+        token = compose_jwt_from_aws_kms_sign_response(
+            signing_input.encode(),
+            kms_sign_resp=der_sig,
+            kms_sign_algorithm=kms_resp["SigningAlgorithm"],
+        )
+
+        # 4a. verifiable by a plain pyJWT consumer
+        assert jwt.decode(token, key=pub_pem, algorithms=[jwt_alg]) == payload
+        # 4b. verifiable through the library's own verification helper
+        assert (
+            get_verified_jwt_payload(
+                token.decode(), pub_key=pub_pem, allowed_algs=[jwt_alg]
+            )
+            == payload
+        )
+
+    def test_tampered_payload_fails_verification(self):
+        priv = ec.generate_private_key(ec.SECP256R1())
+        pub_pem = priv.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+        _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            {"sub": "img"}, {"typ": "JWT"}, alg="ES256"
+        )
+        kms_resp = _simulate_kms_sign_response(
+            priv,
+            signing_input.encode(),
+            digest=hashes.SHA256(),
+            signing_algorithm="ECDSA_SHA_256",
+        )
+        token = compose_jwt_from_aws_kms_sign_response(
+            signing_input.encode(),
+            kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
+            kms_sign_algorithm=kms_resp["SigningAlgorithm"],
+        )
+
+        # flip the payload segment to a different (validly-encoded) value
+        header_seg, _, sig_seg = token.split(b".")
+        forged_payload = base64.urlsafe_b64encode(b'{"sub": "evil"}').rstrip(b"=")
+        forged = header_seg + b"." + forged_payload + b"." + sig_seg
+
+        with pytest.raises(InvalidSignatureError):
+            jwt.decode(forged, key=pub_pem, algorithms=["ES256"])
+
+    def test_wrong_key_fails_verification(self):
+        priv = ec.generate_private_key(ec.SECP256R1())
+        other_pub_pem = (
+            ec.generate_private_key(ec.SECP256R1())
+            .public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        )
+
+        _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            {"sub": "img"}, {"typ": "JWT"}, alg="ES256"
+        )
+        kms_resp = _simulate_kms_sign_response(
+            priv,
+            signing_input.encode(),
+            digest=hashes.SHA256(),
+            signing_algorithm="ECDSA_SHA_256",
+        )
+        token = compose_jwt_from_aws_kms_sign_response(
+            signing_input.encode(),
+            kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
+            kms_sign_algorithm=kms_resp["SigningAlgorithm"],
+        )
+
+        with pytest.raises(InvalidSignatureError):
+            jwt.decode(token, key=other_pub_pem, algorithms=["ES256"])
+
+
+class TestAwsKmsSigningWithIndexJwtReadPath:
+    """A KMS-signed token must be consumable by the existing index_jwt path."""
+
+    def test_kms_signed_index_jwt_verifies_via_index_jwt_utils(
+        self, cert_chain, end_entity_cert, image_descriptor
+    ):
+        from ota_image_libs.v1.index_jwt.schema import IndexJWTClaims
+        from ota_image_libs.v1.index_jwt.utils import (
+            X5C_FNAME,
+            decode_index_jwt_with_verification,
+            get_index_jwt_sign_cert_chain,
+        )
+
+        _, ee_key = end_entity_cert  # conftest end-entity key is P-256 (ES256)
+
+        # Build the same payload/header that compose_index_jwt would, but sign
+        # it via the AWS KMS path instead of with a local private key.
+        claims = IndexJWTClaims(iat=123, image_index=image_descriptor)
+        headers = {X5C_FNAME: cert_chain.serializer()}
+
+        _, signing_input = compose_unsigned_jwt_for_aws_kms_sign(
+            claims.model_dump(by_alias=True, exclude_none=True),
+            headers,
+            alg="ES256",
+        )
+        kms_resp = _simulate_kms_sign_response(
+            ee_key,
+            signing_input.encode(),
+            digest=hashes.SHA256(),
+            signing_algorithm="ECDSA_SHA_256",
+        )
+        token = compose_jwt_from_aws_kms_sign_response(
+            signing_input.encode(),
+            kms_sign_resp=base64.b64decode(kms_resp["Signature"]),
+            kms_sign_algorithm=kms_resp["SigningAlgorithm"],
+        ).decode()
+
+        # the existing read path extracts the x5c chain and verifies the signature
+        extracted_chain = get_index_jwt_sign_cert_chain(token)
+        assert extracted_chain.ee.subject == cert_chain.ee.subject
+
+        verified = decode_index_jwt_with_verification(token, extracted_chain)
+        assert verified.image_index.digest == image_descriptor.digest
+        assert verified.image_index.size == image_descriptor.size

--- a/tests/test_index_jwt_utils.py
+++ b/tests/test_index_jwt_utils.py
@@ -33,14 +33,49 @@ from cryptography.x509 import Certificate
 from cryptography.x509.oid import NameOID
 from jwt.exceptions import InvalidSignatureError
 
+from ota_image_libs._crypto.aws_kms import (
+    AWSKMSSignAlgorithm,
+    compose_jwt_from_aws_kms_sign_response,
+    get_aws_sign_alg,
+)
 from ota_image_libs._crypto.x509_utils import X5cX509CertChain
 from ota_image_libs.common.oci_spec import Sha256Digest
+from ota_image_libs.v1.consts import ALLOWED_JWT_ALG
 from ota_image_libs.v1.image_index.schema import ImageIndex
+from ota_image_libs.v1.index_jwt.schema import IndexJWTClaims
 from ota_image_libs.v1.index_jwt.utils import (
+    X5C_FNAME,
     compose_index_jwt,
+    compose_unsigned_index_jwt_for_aws_kms_sign,
     decode_index_jwt_with_verification,
     get_index_jwt_sign_cert_chain,
 )
+
+
+def _b64url_decode(segment: str) -> bytes:
+    """base64url-decode a JWS segment, restoring the stripped padding."""
+    raw = segment.encode("ascii")
+    raw += b"=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode(raw)
+
+
+def _simulate_kms_es256_sign(
+    priv_key: EllipticCurvePrivateKey, signing_input: str
+) -> str:
+    """Stand in for an AWS KMS ``ECDSA_SHA_256`` ``Sign`` round-trip.
+
+    KMS signs the ``header.payload`` input and returns a DER-encoded ECDSA
+    signature; ``priv_key.sign(..., ec.ECDSA(SHA256))`` produces the same DER
+    form, which we feed back through the library's response composer (along with
+    the original signing input str) to get the complete JWT a caller would
+    obtain after calling KMS.
+    """
+    der_sig = priv_key.sign(signing_input.encode("ascii"), ec.ECDSA(hashes.SHA256()))
+    return compose_jwt_from_aws_kms_sign_response(
+        signing_input,
+        kms_sign_resp=der_sig,
+        kms_sign_algorithm="ECDSA_SHA_256",
+    )
 
 
 class TestIndexJWTUtils:
@@ -425,3 +460,118 @@ class TestDecodeIndexJwtWithVerification:
         # Verify claims are correct
         assert verified_claims.image_index.digest == descriptor.digest
         assert verified_claims.image_index.size == descriptor.size
+
+
+class TestComposeUnsignedIndexJwtForAwsKmsSign:
+    def test_returns_kms_alg_and_two_segment_signing_input(
+        self, cert_chain: X5cX509CertChain, image_descriptor: ImageIndex.Descriptor
+    ):
+        """Returns the KMS algorithm plus the unsigned ``header.payload`` input."""
+        aws_alg, signing_input = compose_unsigned_index_jwt_for_aws_kms_sign(
+            image_descriptor, sign_cert_chain=cert_chain
+        )
+
+        assert isinstance(aws_alg, AWSKMSSignAlgorithm)
+        # the index.jwt alg is fixed to ALLOWED_JWT_ALG (ES256 -> ECDSA_SHA_256)
+        assert aws_alg == AWSKMSSignAlgorithm.ECDSA_SHA_256
+        assert aws_alg == get_aws_sign_alg(ALLOWED_JWT_ALG)
+
+        # signing input is the unsigned `header.payload`, no signature segment yet
+        assert isinstance(signing_input, str)
+        assert signing_input.count(".") == 1
+
+    def test_header_carries_alg_typ_and_x5c_chain(
+        self, cert_chain: X5cX509CertChain, image_descriptor: ImageIndex.Descriptor
+    ):
+        """The JWT header advertises ES256/JWT and embeds the x5c cert chain."""
+        _, signing_input = compose_unsigned_index_jwt_for_aws_kms_sign(
+            image_descriptor, sign_cert_chain=cert_chain
+        )
+
+        header = json.loads(_b64url_decode(signing_input.split(".", 1)[0]))
+        assert header["alg"] == ALLOWED_JWT_ALG
+        assert header["typ"] == "JWT"
+        # x5c carries the base64-DER serialized signing cert chain (RFC 7515)
+        assert header[X5C_FNAME] == cert_chain.serializer()
+
+    def test_payload_carries_image_index_and_iat(
+        self, cert_chain: X5cX509CertChain, image_descriptor: ImageIndex.Descriptor
+    ):
+        """The payload stamps ``iat`` and round-trips the image_index descriptor."""
+        before = int(datetime.now(timezone.utc).timestamp())
+        _, signing_input = compose_unsigned_index_jwt_for_aws_kms_sign(
+            image_descriptor, sign_cert_chain=cert_chain
+        )
+        after = int(datetime.now(timezone.utc).timestamp())
+
+        payload = json.loads(_b64url_decode(signing_input.split(".")[1]))
+
+        assert isinstance(payload["iat"], int)
+        assert before <= payload["iat"] <= after
+
+        # the payload re-validates into the same claims the read path expects
+        claims = IndexJWTClaims.model_validate(payload)
+        assert claims.image_index.digest == image_descriptor.digest
+        assert claims.image_index.size == image_descriptor.size
+
+    def test_x5c_header_uses_chain_serializer_output(
+        self, mocker, image_descriptor: ImageIndex.Descriptor
+    ):
+        """The x5c header is populated verbatim from ``sign_cert_chain.serializer()``."""
+        mock_cert_chain = mocker.MagicMock()
+        mock_cert_chain.serializer.return_value = ["cert-a", "cert-b"]
+
+        _, signing_input = compose_unsigned_index_jwt_for_aws_kms_sign(
+            image_descriptor, sign_cert_chain=mock_cert_chain
+        )
+
+        mock_cert_chain.serializer.assert_called_once_with()
+        header = json.loads(_b64url_decode(signing_input.split(".", 1)[0]))
+        assert header[X5C_FNAME] == ["cert-a", "cert-b"]
+
+
+class TestComposeUnsignedIndexJwtForAwsKmsSignRoundTrip:
+    """A KMS-signed unsigned index.jwt must verify through the read path."""
+
+    def test_full_round_trip_via_index_jwt_read_path(
+        self,
+        cert_chain: X5cX509CertChain,
+        end_entity_cert: tuple[Certificate, EllipticCurvePrivateKey],
+        image_descriptor: ImageIndex.Descriptor,
+    ):
+        """compose unsigned -> KMS sign (simulated) -> extract chain -> verify."""
+        _, ee_key = end_entity_cert  # conftest end-entity key is P-256 (ES256)
+
+        # 1. compose the unsigned signing input for the descriptor
+        aws_alg, signing_input = compose_unsigned_index_jwt_for_aws_kms_sign(
+            image_descriptor, sign_cert_chain=cert_chain
+        )
+        assert aws_alg == AWSKMSSignAlgorithm.ECDSA_SHA_256
+
+        # 2. AWS KMS Sign (simulated with the EE key) + compose the final JWT
+        token = _simulate_kms_es256_sign(ee_key, signing_input)
+        assert token.count(".") == 2
+
+        # 3. the existing read path extracts the x5c chain and verifies the sig
+        extracted_chain = get_index_jwt_sign_cert_chain(token)
+        assert extracted_chain.ee.subject == cert_chain.ee.subject
+
+        verified = decode_index_jwt_with_verification(token, extracted_chain)
+        assert verified.image_index.digest == image_descriptor.digest
+        assert verified.image_index.size == image_descriptor.size
+
+    def test_signature_from_unrelated_key_fails_verification(
+        self, cert_chain: X5cX509CertChain, image_descriptor: ImageIndex.Descriptor
+    ):
+        """A signature from a key unrelated to the x5c end-entity cert is rejected."""
+        _, signing_input = compose_unsigned_index_jwt_for_aws_kms_sign(
+            image_descriptor, sign_cert_chain=cert_chain
+        )
+
+        # sign with a key that does NOT match the end-entity cert in the chain
+        wrong_key = ec.generate_private_key(ec.SECP256R1())
+        token = _simulate_kms_es256_sign(wrong_key, signing_input)
+
+        extracted_chain = get_index_jwt_sign_cert_chain(token)
+        with pytest.raises(InvalidSignatureError):
+            decode_index_jwt_with_verification(token, extracted_chain)

--- a/tests/test_index_jwt_utils.py
+++ b/tests/test_index_jwt_utils.py
@@ -50,13 +50,7 @@ from ota_image_libs.v1.index_jwt.utils import (
     decode_index_jwt_with_verification,
     get_index_jwt_sign_cert_chain,
 )
-
-
-def _b64url_decode(segment: str) -> bytes:
-    """base64url-decode a JWS segment, restoring the stripped padding."""
-    raw = segment.encode("ascii")
-    raw += b"=" * (-len(raw) % 4)
-    return base64.urlsafe_b64decode(raw)
+from tests.conftest import b64url_decode, ecdsa_der_sign
 
 
 def _simulate_kms_es256_sign(
@@ -65,12 +59,11 @@ def _simulate_kms_es256_sign(
     """Stand in for an AWS KMS ``ECDSA_SHA_256`` ``Sign`` round-trip.
 
     KMS signs the ``header.payload`` input and returns a DER-encoded ECDSA
-    signature; ``priv_key.sign(..., ec.ECDSA(SHA256))`` produces the same DER
-    form, which we feed back through the library's response composer (along with
-    the original signing input str) to get the complete JWT a caller would
-    obtain after calling KMS.
+    signature; ``ecdsa_der_sign`` produces the same DER form, which we feed back
+    through the library's response composer (along with the original signing
+    input str) to get the complete JWT a caller would obtain after calling KMS.
     """
-    der_sig = priv_key.sign(signing_input.encode("ascii"), ec.ECDSA(hashes.SHA256()))
+    der_sig = ecdsa_der_sign(priv_key, signing_input.encode("ascii"), hashes.SHA256())
     return compose_jwt_from_aws_kms_sign_response(
         signing_input,
         kms_sign_resp=der_sig,
@@ -488,7 +481,7 @@ class TestComposeUnsignedIndexJwtForAwsKmsSign:
             image_descriptor, sign_cert_chain=cert_chain
         )
 
-        header = json.loads(_b64url_decode(signing_input.split(".", 1)[0]))
+        header = json.loads(b64url_decode(signing_input.split(".", 1)[0]))
         assert header["alg"] == ALLOWED_JWT_ALG
         assert header["typ"] == "JWT"
         # x5c carries the base64-DER serialized signing cert chain (RFC 7515)
@@ -504,7 +497,7 @@ class TestComposeUnsignedIndexJwtForAwsKmsSign:
         )
         after = int(datetime.now(timezone.utc).timestamp())
 
-        payload = json.loads(_b64url_decode(signing_input.split(".")[1]))
+        payload = json.loads(b64url_decode(signing_input.split(".")[1]))
 
         assert isinstance(payload["iat"], int)
         assert before <= payload["iat"] <= after
@@ -526,7 +519,7 @@ class TestComposeUnsignedIndexJwtForAwsKmsSign:
         )
 
         mock_cert_chain.serializer.assert_called_once_with()
-        header = json.loads(_b64url_decode(signing_input.split(".", 1)[0]))
+        header = json.loads(b64url_decode(signing_input.split(".", 1)[0]))
         assert header[X5C_FNAME] == ["cert-a", "cert-b"]
 
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.

-->

This PR adds required helper utils for supporting OTA image signing with AWS KMS. Once this PR is merged, the `ota-image-builder` can utilize the helpers to add new CLI to support OTA image signing with AWS KMS.

This PR will bump `ota-image-libs` to 0.5.0.

## Tickets

https://tier4.atlassian.net/browse/T4DEV-55693