### PR TITLE
feat(image_index): tolerate unknown and mismatched manifest entries

### DIFF
--- a/src/ota_image_libs/common/_common.py
+++ b/src/ota_image_libs/common/_common.py
@@ -61,6 +61,10 @@ def oci_descriptor_before_validator(cls: Any, data: Any, info: ValidationInfo) -
             _schema_ver_checker.validate(data.get("schemaVersion"))
         if _media_type_checker := cls.__dict__.get("MediaType"):
             _media_type_checker.validate(data.get("mediaType"))
+        if (_artifact_type_checker := cls.__dict__.get("ArtifactType")) and (
+            "artifactType" in data
+        ):
+            _artifact_type_checker.validate(data.get("artifactType"))
     return data
 
 

--- a/src/ota_image_libs/v1/image_index/schema.py
+++ b/src/ota_image_libs/v1/image_index/schema.py
@@ -15,9 +15,10 @@
 from __future__ import annotations
 
 import time
-from typing import List, Union
+from typing import Any, List, Union
 
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Annotated
 
 from ota_image_libs.common import (
     AliasEnabledModel,
@@ -25,6 +26,7 @@ from ota_image_libs.common import (
     MetaFileBase,
     MetaFileDescriptor,
     SchemaVersion,
+    Sha256Digest,
 )
 from ota_image_libs.v1.annotation_keys import (
     BUILD_TOOL_VERSION,
@@ -52,6 +54,21 @@ from ota_image_libs.v1.resource_table.schema import (
     ResourceTableDescriptor,
     ZstdCompressedResourceTableDescriptor,
 )
+
+
+class UnknownManifestDescriptor(BaseModel):
+    """Catch-all for index.json manifest entries this library version does not
+    recognize (forward compatibility). Any well-formed OCI descriptor —
+    mediaType + digest + size — parses; every field is preserved on re-export.
+    Unknown entries are deliberately invisible to the typed helpers below."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    mediaType: str
+    artifactType: Union[str, None] = None
+    size: int
+    digest: Sha256Digest
+    annotations: Any = None
 
 
 class ImageIndex(MetaFileBase):
@@ -88,11 +105,15 @@ class ImageIndex(MetaFileBase):
     MediaType = MediaType[IMAGE_INDEX]
 
     manifests: List[
-        Union[
-            ImageManifest.Descriptor,
-            OTAClientPackageManifest.Descriptor,
-            ResourceTableDescriptor,
-            ZstdCompressedResourceTableDescriptor,
+        Annotated[
+            Union[
+                ImageManifest.Descriptor,
+                OTAClientPackageManifest.Descriptor,
+                ResourceTableDescriptor,
+                ZstdCompressedResourceTableDescriptor,
+                UnknownManifestDescriptor,
+            ],
+            Field(union_mode="left_to_right"),
         ]
     ]
     annotations: Annotations

--- a/tests/test_image_index.py
+++ b/tests/test_image_index.py
@@ -21,6 +21,7 @@ import pytest
 from ota_image_libs.v1.consts import IMAGE_INDEX_FNAME, RESOURCE_DIR
 from ota_image_libs.v1.image_index.schema import ImageIndex, UnknownManifestDescriptor
 from ota_image_libs.v1.image_index.utils import ImageIndexHelper
+from ota_image_libs.v1.image_manifest.schema import ImageManifest
 
 
 @pytest.fixture
@@ -204,3 +205,36 @@ class TestUnknownManifestTolerance:
         assert not any(
             isinstance(m, UnknownManifestDescriptor) for m in index.manifests
         )
+
+    def test_unknown_artifact_type_falls_to_unknown_descriptor(self):
+        entry = {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "artifactType": "application/vnd.tier4.SOMETHING-NEW.v9",
+            "digest": "sha256:" + "1" * 64,
+            "size": 99,
+        }
+        index = ImageIndex.parse_metafile(_index_json_with([entry]))
+        assert isinstance(index.manifests[0], UnknownManifestDescriptor)
+        # regression: this used to misclassify as ImageManifest.Descriptor,
+        # REWRITE artifactType on export, and crash image_identifiers
+        assert index.image_identifiers is None or index.image_identifiers == []
+        exported = json.loads(index.export_metafile())["manifests"][0]
+        assert exported["artifactType"] == entry["artifactType"]
+
+    def test_entry_without_artifact_type_still_classifies_known(
+        self, extracted_ota_image
+    ):
+        # producers that omit artifactType must keep classifying as before
+        index_f = extracted_ota_image / "index.json"
+        raw_manifests = json.loads(index_f.read_text())["manifests"]
+        entry = dict(
+            next(
+                m
+                for m in raw_manifests
+                if m["mediaType"] == "application/vnd.oci.image.manifest.v1+json"
+            )
+        )
+        del entry["artifactType"]
+
+        index = ImageIndex.parse_metafile(_index_json_with([entry]))
+        assert isinstance(index.manifests[0], ImageManifest.Descriptor)

--- a/tests/test_image_index.py
+++ b/tests/test_image_index.py
@@ -19,7 +19,7 @@ import json
 import pytest
 
 from ota_image_libs.v1.consts import IMAGE_INDEX_FNAME, RESOURCE_DIR
-from ota_image_libs.v1.image_index.schema import ImageIndex
+from ota_image_libs.v1.image_index.schema import ImageIndex, UnknownManifestDescriptor
 from ota_image_libs.v1.image_index.utils import ImageIndexHelper
 
 
@@ -155,3 +155,52 @@ class TestImageIndexIntegration:
         assert "annotations" in parsed_back
         assert parsed_back["annotations"][BUILD_TOOL_VERSION] == "test-1.0.0"
         assert parsed_back["annotations"][OTA_IMAGE_CREATED_AT] == 1704067200
+
+
+UNKNOWN_ENTRY = {
+    "mediaType": "application/vnd.example.future-payload.v9+json",
+    "artifactType": "application/vnd.example.future-payload.v9",
+    "digest": "sha256:" + "0" * 64,
+    "size": 1234,
+    "futureField": {"nested": True},
+}
+
+
+def _index_json_with(entries):
+    return json.dumps(
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": entries,
+            "annotations": {"vnd.tier4.ota.ota-image-builder.version": "test-1.0.0"},
+        }
+    )
+
+
+class TestUnknownManifestTolerance:
+    def test_unknown_media_type_entry_parses(self):
+        index = ImageIndex.parse_metafile(_index_json_with([UNKNOWN_ENTRY]))
+        entry = index.manifests[0]
+        assert isinstance(entry, UnknownManifestDescriptor)
+        assert entry.mediaType == UNKNOWN_ENTRY["mediaType"]
+
+    def test_unknown_entry_round_trips(self):
+        index = ImageIndex.parse_metafile(_index_json_with([UNKNOWN_ENTRY]))
+        exported = json.loads(index.export_metafile())["manifests"][0]
+        assert exported["mediaType"] == UNKNOWN_ENTRY["mediaType"]
+        assert exported["artifactType"] == UNKNOWN_ENTRY["artifactType"]
+        assert exported["futureField"] == {"nested": True}
+
+    def test_unknown_entries_invisible_to_helpers(self):
+        index = ImageIndex.parse_metafile(_index_json_with([UNKNOWN_ENTRY]))
+        assert index.image_identifiers == []
+        assert index.image_resource_table is None
+
+    def test_known_entry_still_wins_over_fallback(self, extracted_ota_image):
+        # Round-trip the real fixture image's index: every entry must classify
+        # as a KNOWN descriptor type, none as UnknownManifestDescriptor.
+        index_f = extracted_ota_image / "index.json"
+        index = ImageIndex.parse_metafile(index_f.read_text())
+        assert not any(
+            isinstance(m, UnknownManifestDescriptor) for m in index.manifests
+        )


### PR DESCRIPTION
## Description

A manifest entry in `index.json` that this library version does not recognize currently makes the **whole index unparseable**. That blocks payload evolution: adding any new manifest type breaks every already-pinned client, so new types cannot be rolled out incrementally.

Two failure modes are fixed:

1. **Unknown `mediaType`** → `ValidationError` for the entire `index.json`. Now falls back to a new `UnknownManifestDescriptor` catch-all, preserving all fields on re-export.
2. **Known `mediaType` + foreign `artifactType`** → silently misclassified as that known type, and `export_metafile()` rewrote `artifactType` to the class constant, mutating data on round-trip. Now falls through to the catch-all instead.

## Check list

- [x] test file(s) that cover the change(s) are implemented.
- [x] local tests are passing.
- [ ] design docs/implementation docs are prepared.

## Documents

No separate design document. The change is confined to the `ImageIndex.manifests` union and the shared OCI descriptor validator; the rationale and the measured behaviour are in this description.

## Changes

- `v1/image_index/schema.py`: add `UnknownManifestDescriptor` (plain `BaseModel`, `extra="allow"`), appended as the **last** member of `ImageIndex.manifests`'s union, with `union_mode="left_to_right"` so known members keep winning.
- `common/_common.py`: `oci_descriptor_before_validator` now also validates `artifactType` against the class constant, guarded by `"artifactType" in data` so producers that omit the key are unaffected.
- `tests/test_image_index.py`: 6 new tests. Suite `294 passed, 2 skipped`.

`union_mode="left_to_right"` is load-bearing — under pydantic's default smart union all three real fixture entries collapse into the catch-all.

## Behavior changes

- [ ] Yes, internal behavior (will not impact user experience).
- [x] Yes, external behavior (will impact user experience).
- [ ] No.

### Previous behavior

- Index containing an unknown entry: `ValidationError`, whole index unusable.
- Entry with a contradicting `artifactType`: parsed as the known type; `artifactType` silently rewritten on export.

### Behavior with this PR

- Unknown entry parses as `UnknownManifestDescriptor` and round-trips with its original fields; it stays invisible to the typed helpers (`image_resource_table`, `image_identifiers`, `find_image`, `find_otaclient_package`, `update_resource_table`).
- Contradicting `artifactType` falls back to the catch-all with its value preserved.
- Every entry that classified as a known type before still does — pinned by `test_known_entry_still_wins_over_fallback` and `test_entry_without_artifact_type_still_classifies_known`.

**Known limitations**

1. **Tolerance is sha256-only.** `UnknownManifestDescriptor.digest` is `Sha256Digest`, so an entry with e.g. a `sha512:` digest still matches no union member and still fails the whole parse. Deliberate: the format is sha256 throughout (the JWT anchors on `ImageIndex.Descriptor`, itself a `Sha256Digest`), so widening only the catch-all would let an entry parse that nothing else could verify. If a second algorithm is ever adopted, the change belongs on `Sha256Digest` as a whole.
2. **Metafile path.** The same validator backs `MetaFileBase`, which has no union fallback, so `ImageManifest.parse_metafile()` with a contradicting `artifactType` now **raises** where it previously parsed and dropped the key. Exposure is nil — no producer emits `artifactType` on metafiles — but flagging it in case you prefer a warning here.
3. The check runs in JSON mode only, matching the pre-existing `mediaType` check.

## Breaking change

- [ ] Yes.
- [x] No.

No already-valid `index.json` changes classification. The only differences are entries that previously failed or were silently misclassified. See Known limitation 2 for the one non-additive edge.

## Related links & tickets

`index.jwt` signs a sha256 digest + size commitment of the exact `index.json` bytes, not the bytes inline — so re-exporting a tolerated index requires re-signing, while parse-only clients (the forward-compat case this targets) are unaffected.

Rollout: merge → cut `v0.5.2` → bump the pin in [`tier4/ota-client`](https://github.com/tier4/ota-client) and [`tier4/ota-image-builder`](https://github.com/tier4/ota-image-builder). Both pin a release-wheel URL with an embedded `#sha256:` in `pyproject.toml`, so each bump is one line there plus regenerated `requirements.txt`/`uv.lock`. Precedent: [tier4/ota-client#785](https://github.com/tier4/ota-client/pull/785).
